### PR TITLE
deleteReply：修正在评论列表页面中匹配评论url的规则

### DIFF
--- a/src/deleteReply.js
+++ b/src/deleteReply.js
@@ -94,7 +94,7 @@ async function getOnePage(page) {
   const response = await request(url)
   const data = await response.text()
   const $ = cheerio.load(data)
-  const list = $('a.b_reply').map((index, el) => {
+  const list = $('a.for_reply_context').map((index, el) => {
     const href = $(el).attr('href')
     let tid = href.match(/\/p\/([0-9]+)/) 
     tid = tid && tid[1] || null // 帖子id


### PR DESCRIPTION
原有的"a.b_reply"会为每一项匹配到一个多余的链接，使用"a.for_reply_context'"可精确匹配